### PR TITLE
sequential numbering

### DIFF
--- a/flowplayer.thumbnails.js
+++ b/flowplayer.thumbnails.js
@@ -45,15 +45,9 @@
 
             var c = video.thumbnails || api.conf.thumbnails,
                 preloadImages = function (tmpl, max, start) {
-                    var add = 1;
                     if (start === undefined) {
                         start = 1;
                     }
-                    /* round up by interval ex: 4,8,12,16 */
-                    if(c.interval !== undefined && c.interval > 1) {
-                        start = start + (c.interval - (start % c.interval));
-                        add = c.interval; 
-                    }   
                     function load() {
                         if (start > max) {
                             return;
@@ -61,7 +55,7 @@
                         var img = new Image();
                         img.src = tmpl.replace('{time}', start);
                         img.onload = function () {
-                            start += add;
+                            start += 1;
                             load();
                         };
                     }
@@ -80,13 +74,13 @@
                     percentage = delta / common.width(timeline),
                     seconds = Math.round(percentage * api.video.duration);
 
-                /* round up by interval ex: 4,8,12,16, -1 for compatibility */
-                if(c.interval !== undefined && c.interval > 1) {
-                  seconds = seconds + (c.interval - (seconds % c.interval)) - 1;
-                }
                 // 2nd condition safeguards at out of range retrieval attempts
                 if (seconds < 0 || seconds > Math.round(api.video.duration)) {
                     return;
+                }
+                /* enables greater interval than one second between thumbnails */
+                if(c.interval !== undefined && c.interval > 1 && seconds > 0) {
+                  seconds = Math.ceil(seconds / c.interval) -1;
                 }
                 var height = c.height || 80;
                 common.css(timelineTooltip, {


### PR DESCRIPTION
Edited to allow greater interval than one second between thumbnails but use an sequential numbering instead of seconds from start..
